### PR TITLE
Prevent response callback from exploding when json.items is not present

### DIFF
--- a/squarespace-middleware.js
+++ b/squarespace-middleware.js
@@ -348,7 +348,7 @@ getQuery = function ( data, qrs, callback ) {
         var items = [];
 
         // Featured?
-        if ( data.featured ) {
+        if ( data.featured && json.items ) {
             for ( i = 0, len = json.items.length; i < len; i++ ) {
                 if ( json.items[ i ].starred ) {
                     items.push( json.items[ i ] );
@@ -359,7 +359,7 @@ getQuery = function ( data, qrs, callback ) {
         }
 
         // Limit?
-        if ( data.limit ) {
+        if ( data.limit && json.items ) {
             json.items.splice( 0, (json.items.length - data.limit) );
         }
 


### PR DESCRIPTION
I was encountering the following error loading the Bedford template, this adds a layer of protection and may even fix kitajchuk/node-squarespace-server#12.
```sh
TypeError: Cannot read property 'length' of undefined
    at Request._callback (/opt/local/lib/node_modules/node-squarespace-server/node_modules/node-squarespace-middleware/squarespace-middleware.js:363:46)
    at Request.self.callback (/opt/local/lib/node_modules/node-squarespace-server/node_modules/request/request.js:373:22)
    at Request.emit (events.js:98:17)
    at Request.<anonymous> (/opt/local/lib/node_modules/node-squarespace-server/node_modules/request/request.js:1318:14)
    at Request.emit (events.js:117:20)
    at IncomingMessage.<anonymous> (/opt/local/lib/node_modules/node-squarespace-server/node_modules/request/request.js:1266:12)
    at IncomingMessage.emit (events.js:117:20)
    at _stream_readable.js:943:16
    at process._tickCallback (node.js:419:13)
```